### PR TITLE
fix some "Incomplete string escaping or encoding" errors by CodeQL

### DIFF
--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1805,7 +1805,7 @@ function bootstrap(element, modules, config) {
       throw ngMinErr(
           'btstrpd',
           'App already bootstrapped with this element \'{0}\'',
-          tag.replace(/</g, '&lt;').replace(/>/g, '&gt;')); // Added 'g' flag to replace all 
+          tag.replace(/</g, '&lt;').replace(/>/g, '&gt;'));// Added 'g' flag to replace all
     }
 
     modules = modules || [];

--- a/src/Angular.js
+++ b/src/Angular.js
@@ -1805,7 +1805,7 @@ function bootstrap(element, modules, config) {
       throw ngMinErr(
           'btstrpd',
           'App already bootstrapped with this element \'{0}\'',
-          tag.replace(/</,'&lt;').replace(/>/,'&gt;'));
+          tag.replace(/</g, '&lt;').replace(/>/g, '&gt;')); // Added 'g' flag to replace all 
     }
 
     modules = modules || [];

--- a/src/routeToRegExp.js
+++ b/src/routeToRegExp.js
@@ -30,7 +30,7 @@ function routeToRegExp(path, opts) {
         (optional ? '?)?' : ')')
       );
     })
-    .replace(/([/$*])/g, '\\$1');
+    .replace(/([/$*\\])/g, '\\$1'); // Added backslash to the character class
 
   if (opts.ignoreTrailingSlashes) {
     pattern = pattern.replace(/\/+$/, '') + '/*';


### PR DESCRIPTION
Two issues are reported by CodeQL in the built files.
https://codeql.microsoft.com/viewsarif/9fa8746c-3ab7-4da8-b64d-68d686068ad7


"This replaces only the first occurrence of /</."
"This replaces only the first occurrence of />/."
app/dist/libs.js 2:3028229

                if ((t = a(t)).injector()) {
                    var i = t[0] === e.document ? "document" : we(t);
                    throw _("btstrpd", "App already bootstrapped with this element '{0}'", i.replace(/</, "&lt;").replace(/>/, "&gt;"))
                }

"angular": "^1.8.3",

"This does not escape backslash characters in the input."
app/dist/libs.js 2:3028228

            r = e.replace(/([().])/g, "\\$1").replace(/(\/)?:(\w+)(\*\?|[?*])?/g, (function(e, t, r, i) {
                var o = "?" === i || "*?" === i
                  , a = "*" === i || "*?" === i;
                return n.push({
                    name: r,
                    optional: o
                }),
                t = t || "",
                (o ? "(?:" + t : t + "(?:") + (a ? "(.+?)" : "([^/]+)") + (o ? "?)?" : ")")
            }
            )).replace(/([/$*])/g, "\\$1");
"angular-route": "^1.8.3",


Addressing them in this PR.